### PR TITLE
Add the typescript definitions to the package

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "README.md",
         "dist/",
         "lib/",
-        "index.lodash.d.ts
+        "index.lodash.d.ts"
     ],
     "main": "dist/lodash-joins.js",
     "types": "index.lodash.d.ts",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
         "LICENSE",
         "README.md",
         "dist/",
-        "lib/"
+        "lib/",
+        "index.lodash.d.ts
     ],
     "main": "dist/lodash-joins.js",
     "types": "index.lodash.d.ts",


### PR DESCRIPTION
I just noticed that v3 doesn't include the Typescript definitions in the outputted package. This change should include the Typescript definitions file in the published package.